### PR TITLE
PF-48: Fix Build Assets URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm run test:ci
 
       - name: Build
-        run: npm run build
+        run: npm run build -- --base-href=/portfolio/
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
Summary of changes:
- added /portfolio/ to base href in the deployment pipeline

Closes #48 